### PR TITLE
v5.8.0 - Açı Matrisi (Aspectarian): Astrodienst tarzı üçgen açı tablosu

### DIFF
--- a/astrology.css
+++ b/astrology.css
@@ -407,6 +407,86 @@ body {
 
 .data-table tr:nth-child(even) { background: #faf9ff; }
 
+/* ============ AÇI MATRİSİ (ASPECTARIAN) ============ */
+.grid-section { margin-bottom: 22px; }
+
+.grid-title {
+    font-size: 14px;
+    color: #4a2580;
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.grid-note {
+    font-size: 12px;
+    color: #888;
+    margin-bottom: 12px;
+    line-height: 1.5;
+}
+
+.aspect-grid-wrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 4px;
+}
+
+.aspect-grid {
+    border-collapse: collapse;
+    margin: 0 auto;
+}
+
+.aspect-grid td {
+    width: 34px;
+    height: 34px;
+    min-width: 34px;
+    text-align: center;
+    vertical-align: middle;
+    border: 1px solid #e2ddf5;
+    padding: 0;
+    line-height: 1.05;
+}
+
+.aspect-grid .ag-cell { background: white; }
+.aspect-grid .ag-cell.empty { background: #fbfaff; }
+
+.aspect-grid .ag-sym {
+    display: block;
+    font-size: 15px;
+    font-weight: 700;
+}
+
+.aspect-grid .ag-orb {
+    display: block;
+    font-size: 8.5px;
+    color: #999;
+}
+
+.aspect-grid .ag-diag {
+    background: linear-gradient(135deg, #f4f0ff, #ece5fc);
+    font-size: 15px;
+    font-weight: 700;
+    border: 1px solid #cfc4ef;
+}
+
+.grid-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 16px;
+    margin-top: 12px;
+    font-size: 11.5px;
+    color: #666;
+    justify-content: center;
+}
+
+.grid-legend .gl-item { white-space: nowrap; }
+.grid-legend .ag-sym { display: inline; font-size: 13px; }
+
+@media (max-width: 480px) {
+    .aspect-grid td { width: 28px; height: 30px; min-width: 28px; }
+    .aspect-grid .ag-sym { font-size: 13px; }
+    .aspect-grid .ag-orb { font-size: 7.5px; }
+}
+
 /* Yorum & Günlük Fal */
 .reading { padding: 4px 8px; }
 

--- a/astrology.html
+++ b/astrology.html
@@ -12,7 +12,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="astrology.css?v=5.7.1">
+    <link rel="stylesheet" href="astrology.css?v=5.8.0">
 </head>
 <body>
     <!-- Üst Bar -->
@@ -22,7 +22,7 @@
                 <span class="top-bar-title">✨ Astro Harita</span>
                 <span class="top-bar-sub">Doğum haritası · Yorum · Günlük fal</span>
             </div>
-            <span class="badge">v5.7.1</span>
+            <span class="badge">v5.8.0</span>
         </div>
     </div>
 
@@ -174,6 +174,15 @@
         </div>
 
         <div class="tab-content" id="tab-aspects">
+            <div class="grid-section">
+                <h4 class="grid-title">🔺 Açı Matrisi (Aspectarian)</h4>
+                <p class="grid-note">Klasik harita çıktılarındaki üçgen tablo: her hücre, satır ve sütundaki iki gezegen arasındaki açıyı gösterir. AC (Yükselen) ve MC dahildir.</p>
+                <div class="aspect-grid-wrap">
+                    <table class="aspect-grid" id="aspect-grid"></table>
+                </div>
+                <div class="grid-legend" id="grid-legend"></div>
+            </div>
+            <h4 class="grid-title">📋 Açı Listesi</h4>
             <table class="data-table" id="aspects-table">
                 <thead><tr><th>Gezegen</th><th>Aspect</th><th>Gezegen</th><th>Orb</th></tr></thead>
                 <tbody></tbody>
@@ -198,7 +207,7 @@
             <div id="dominants-content"></div>
         </div>
 
-        <div class="footer-pill">✨ KUBEY Astroloji v5.7.1</div>
+        <div class="footer-pill">✨ KUBEY Astroloji v5.8.0</div>
     </div>
 
     <!-- Chatbot -->
@@ -224,6 +233,6 @@
         </div>
     </div>
 
-    <script src="astrology.js?v=5.7.1"></script>
+    <script src="astrology.js?v=5.8.0"></script>
 </body>
 </html>

--- a/astrology.js
+++ b/astrology.js
@@ -1,7 +1,7 @@
-// KUBEY Astroloji v5.7.1 - Kısa/Detaylı yorum + Günlük/Haftalık/Aylık fal + Sinastri + Transitler + PWA
-console.log('🌟 Astroloji v5.7.1 yükleniyor...');
+// KUBEY Astroloji v5.8.0 - Kısa/Detaylı yorum + Günlük/Haftalık/Aylık fal + Sinastri + Transitler + PWA
+console.log('🌟 Astroloji v5.8.0 yükleniyor...');
 
-const APP_VERSION = '5.7.1';
+const APP_VERSION = '5.8.0';
 
 const DEG = Math.PI / 180;
 
@@ -917,6 +917,66 @@ function fillPositions(c) {
             <td>${fmtDegMin(lon)}</td>
             <td>${house}</td>
         </tr>`;
+    }
+}
+
+// Astrodienst tarzı üçgen açı matrisi (aspectarian).
+// Majör açılara ek olarak matriste minör açılar da gösterilir (listeyi/çarkı etkilemez).
+const GRID_MINOR_ASPECTS = [
+    { name: 'Yüzellilik (Quincunx)', symbol: '⚻', angle: 150, orb: 3, color: '#2e8b57' },
+    { name: 'Yarım Altmışlık', symbol: '⚺', angle: 30, orb: 2, color: '#2e8b57' },
+    { name: 'Yarım Kare', symbol: '∠', angle: 45, orb: 2, color: '#b05a2a' },
+    { name: 'Birbuçuk Kare', symbol: '⚼', angle: 135, orb: 2, color: '#b05a2a' }
+];
+
+function gridAspectBetween(lon1, lon2) {
+    let diff = Math.abs(lon1 - lon2);
+    if (diff > 180) diff = 360 - diff;
+    for (const asp of ASPECT_TYPES) {
+        const orb = Math.abs(diff - asp.angle);
+        if (orb <= asp.orb) return { type: asp, orb };
+    }
+    for (const asp of GRID_MINOR_ASPECTS) {
+        const orb = Math.abs(diff - asp.angle);
+        if (orb <= asp.orb) return { type: asp, orb };
+    }
+    return null;
+}
+
+function fillAspectGrid(c) {
+    const table = document.getElementById('aspect-grid');
+    if (!table) return;
+    
+    const bodies = Object.keys(PLANETS).map(k => ({
+        key: k, name: PLANETS[k].name, symbol: PLANETS[k].symbol, color: PLANETS[k].color, lon: c.positions[k].lon
+    }));
+    bodies.push({ key: 'asc', name: 'Yükselen', symbol: 'AC', color: '#111', lon: c.asc });
+    bodies.push({ key: 'mc', name: 'Gökyüzü Ortası', symbol: 'MC', color: '#111', lon: c.mc });
+    
+    let html = '';
+    for (let i = 0; i < bodies.length; i++) {
+        html += '<tr>';
+        for (let j = 0; j < i; j++) {
+            const a = gridAspectBetween(bodies[i].lon, bodies[j].lon);
+            if (a) {
+                html += `<td class="ag-cell" title="${bodies[i].name} ${a.type.name} ${bodies[j].name} (orb ${a.orb.toFixed(1)}°)">
+                    <span class="ag-sym" style="color:${a.type.color}">${a.type.symbol}</span>
+                    <span class="ag-orb">${a.orb.toFixed(1)}</span></td>`;
+            } else {
+                html += '<td class="ag-cell empty"></td>';
+            }
+        }
+        html += `<td class="ag-diag" title="${bodies[i].name}"><span style="color:${bodies[i].color}">${bodies[i].symbol}</span></td>`;
+        html += '</tr>';
+    }
+    table.innerHTML = html;
+    
+    // Lejant: majör + minör açı sembolleri
+    const legend = document.getElementById('grid-legend');
+    if (legend) {
+        legend.innerHTML = [...ASPECT_TYPES, ...GRID_MINOR_ASPECTS].map(a =>
+            `<span class="gl-item"><span class="ag-sym" style="color:${a.color}">${a.symbol}</span> ${a.name} (${a.angle}°)</span>`
+        ).join('');
     }
 }
 
@@ -2631,6 +2691,7 @@ function generateAll() {
     drawWheel(c);
     fillPositions(c);
     fillAspects(c);
+    fillAspectGrid(c);
     fillHouses(c);
     fillDominants(c);
     fillInterpretation(c);

--- a/sw.js
+++ b/sw.js
@@ -1,10 +1,10 @@
-// KUBEY Astroloji Service Worker - v5.7.1
-const CACHE_NAME = 'astro-v5.7.1';
+// KUBEY Astroloji Service Worker - v5.8.0
+const CACHE_NAME = 'astro-v5.8.0';
 
 const PRECACHE = [
     './astrology.html',
-    './astrology.css?v=5.7.1',
-    './astrology.js?v=5.7.1',
+    './astrology.css?v=5.8.0',
+    './astrology.js?v=5.8.0',
     './manifest.json',
     './icon-192.png',
     './icon-512.png'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## v5.8.0 — Açı Matrisi (Aspectarian)

Kullanıcının paylaştığı görsel, Astrodienst (astro.com) tarzı klasik bir doğum haritası çıktısıydı. Görseldeki sol alt köşede yer alan üçgen yapı bir **açı matrisi (aspectarian)** — bu yapı sisteme eklendi.

### Eklenenler

- **Üçgen açı matrisi** "🔺 Açılar" sekmesinin en üstüne eklendi:
  - Satır/sütunlarda 10 gezegen + AC (Yükselen) + MC; köşegen hücrelerde renkli gezegen sembolleri.
  - Her hücrede iki gezegen arasındaki açının sembolü (türüne göre renkli) ve orb değeri.
  - Hücre üzerine gelince başlık metni: örn. "Ay Kare Güneş (orb 6.4°)".
- **Minör açılar** yalnızca matriste gösterilir (çark çizimi ve açı listesi etkilenmez): Yüzellilik/Quincunx (150°, orb 3°), Yarım Altmışlık (30°, orb 2°), Yarım Kare (45°, orb 2°), Birbuçuk Kare (135°, orb 2°).
- **Lejant:** 5 majör + 4 minör açının sembolü, adı ve derecesi.
- **Mobil uyum:** 480px altında daha küçük hücreler; gerekirse yatay kaydırma.

### Doğrulama

Playwright ile kontrol edildi: 12 satır (10 gezegen + AC + MC), üçgen yapı doğru (ilk satır 1 hücre, son satır 12 hücre), 32 dolu açı hücresi, örnek hücre başlığı doğru, 9 lejant öğesi, mevcut açı listesi bozulmadı. Sayfa hatası yok.

[Mobil açı matrisi](https://cursor.com/agents/bc-019f66f8-210f-7b67-a13f-38b5988669af/artifacts?path=%2Ftmp%2Faspect-grid-mobile.png)
[Masaüstü açı matrisi](https://cursor.com/agents/bc-019f66f8-210f-7b67-a13f-38b5988669af/artifacts?path=%2Ftmp%2Faspect-grid-desktop.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f66f8-210f-7b67-a13f-38b5988669af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f66f8-210f-7b67-a13f-38b5988669af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

